### PR TITLE
Fixes

### DIFF
--- a/Sources/mpc-core-kit-swift/CoreKitStorage.swift
+++ b/Sources/mpc-core-kit-swift/CoreKitStorage.swift
@@ -47,10 +47,10 @@ public class CoreKitStorage {
         return resultStr
     }
     
-    public func getStore() async throws -> [String: Codable] {
+    public func getStore() async throws -> [String: Any] {
         let result = try await self.storage.get(key: self.storeKey)
         if result.isEmpty { return [:] }
-        let store = try JSONSerialization.jsonObject(with: result) as? [String: Codable]
+        let store = try JSONSerialization.jsonObject(with: result) as? [String: Any]
         guard let storeUnwrapped = store else {
             return [:]
         }

--- a/Sources/mpc-core-kit-swift/CoreKitStorage.swift
+++ b/Sources/mpc-core-kit-swift/CoreKitStorage.swift
@@ -92,8 +92,8 @@ class DeviceFactorStorage : IFactorStorage {
     }
     
     public func setFactor(metadataPubKey: String, factorKey: String) async throws {
-        var localMetadata : [String: Codable] = [:]
-        let result : [String: Codable]?  = try? await self.storage.get(key: metadataPubKey)
+        var localMetadata : [String: Any] = [:]
+        let result : [String: Any]?  = try? await self.storage.get(key: metadataPubKey)
         if let result = result {
             localMetadata = result
         }
@@ -102,7 +102,7 @@ class DeviceFactorStorage : IFactorStorage {
     }
     
     public func getFactor(metadataPubKey: String) async throws -> String {
-        let localMetadata : [String: Codable]?  = try? await self.storage.get(key: metadataPubKey)
+        let localMetadata : [String: Any]?  = try? await self.storage.get(key: metadataPubKey)
         guard let localMetadata = localMetadata, let deviceFactor = localMetadata["factorKey"] as? String else {
             throw "device factor not found"
         }

--- a/Sources/mpc-core-kit-swift/Helper.swift
+++ b/Sources/mpc-core-kit-swift/Helper.swift
@@ -22,7 +22,7 @@ func convertPublicKeyFormat ( publicKey: String, outFormat: PublicKeyEncoding ) 
 }
 
 
-public func createCoreKitFactorDescription ( module: FactorDescriptionTypeModule, tssIndex: TssShareType, additional : [String:Codable] = [:] ) -> [String: Codable] {
+public func createCoreKitFactorDescription ( module: FactorDescriptionTypeModule, tssIndex: TssShareType, additional : [String:Any] = [:] ) -> [String: Any] {
     var description = additional
     
     description["module"] = module.toString()
@@ -32,7 +32,7 @@ public func createCoreKitFactorDescription ( module: FactorDescriptionTypeModule
     return description
 }
 
-func factorDescriptionToJsonStr ( dataObj: [String: Codable]  ) throws -> String {
+func factorDescriptionToJsonStr ( dataObj: [String: Any]  ) throws -> String {
     let json = try JSONSerialization.data(withJSONObject: dataObj)
     guard let jsonStr = String(data: json, encoding: .utf8) else {
         throw "Invalid data structure"

--- a/Sources/mpc-core-kit-swift/Interface.swift
+++ b/Sources/mpc-core-kit-swift/Interface.swift
@@ -168,9 +168,9 @@ public enum TssShareType {
 public struct enableMFARecoveryFactor {
     public var factorKey: String?
     public var factorTypeDescription: FactorDescriptionTypeModule
-    public var additionalMetadata: [String:Codable]
+    public var additionalMetadata: [String:Any]
     
-    public init(factorKey: String? = nil, factorTypeDescription: FactorDescriptionTypeModule = .Other, additionalMetadata: [String : Codable] = [:]) {
+    public init(factorKey: String? = nil, factorTypeDescription: FactorDescriptionTypeModule = .Other, additionalMetadata: [String : Any] = [:]) {
         self.factorKey = factorKey
         self.factorTypeDescription = factorTypeDescription
         self.additionalMetadata = additionalMetadata

--- a/Sources/mpc-core-kit-swift/mpcCoreKitSwift.swift
+++ b/Sources/mpc-core-kit-swift/mpcCoreKitSwift.swift
@@ -311,9 +311,10 @@ public struct MpcCoreKit  {
         try await tkey.add_share_description(key: factorPub, description: jsonStr )
 
         self.factorKey = factorKey;
+        let deviceMetadataShareIndex = try await  TssModule.find_device_share_index(threshold_key: tkey, factor_key: factorKey)
         
         let metadataPubKey = try tkey.get_key_details().pub_key.getPublicKey(format: .EllipticCompress)
-        try await self.updateAppState(state: .init(factorKey: factorKey, metadataPubKey: metadataPubKey))
+        try await self.updateAppState(state: .init(factorKey: factorKey, metadataPubKey: metadataPubKey, deviceMetadataShareIndex: deviceMetadataShareIndex))
         
         // save as device factor if hashfactor is disable
         if ( self.option.disableHashFactor == true ) {

--- a/Sources/mpc-core-kit-swift/mpcCoreKitSwift.swift
+++ b/Sources/mpc-core-kit-swift/mpcCoreKitSwift.swift
@@ -96,7 +96,7 @@ public struct MpcCoreKit  {
         return shareIndex
     }
     
-    public mutating func login (loginProvider: LoginProviders, clientId: String, verifier: String , jwtParams: [String: String] = [:], redirectURL: String = "tdsdk://tdsdk/oauthCallback", browserRedirectURL: String = "https://scripts.toruswallet.io/redirect.html" ) async throws -> MpcKeyDetails {
+    public mutating func loginWithOAuth(loginProvider: LoginProviders, clientId: String, verifier: String , jwtParams: [String: String] = [:], redirectURL: String = "tdsdk://tdsdk/oauthCallback", browserRedirectURL: String = "https://scripts.toruswallet.io/redirect.html" ) async throws -> MpcKeyDetails {
         if loginProvider == .jwt && jwtParams.isEmpty {
             throw "jwt login should provide jwtParams"
         }
@@ -236,18 +236,15 @@ public struct MpcCoreKit  {
         // try check for hash factor
         if ( self.option.disableHashFactor == false) {
             factor = try? self.getHashKey()
-            // factor not found, return and request factor from inputFactor function
-            guard let factor = factor else {
-                print("device Factor not found")
-                return
-            }
-            
-            do {
-                try await self.inputFactor(factorKey: factor)
-                self.factorKey = factor
-                return
-            } catch {
-                // swallow on invalid hashFactor
+            // if factor not found, continue forward and try to retrive device factor
+            if factor != nil {
+                do {
+                    try await self.inputFactor(factorKey: factor)
+                    self.factorKey = factor
+                    return
+                } catch {
+                    // swallow on invalid hashFactor
+                }
             }
         }
         

--- a/Sources/mpc-core-kit-swift/mpcCoreKitSwift.swift
+++ b/Sources/mpc-core-kit-swift/mpcCoreKitSwift.swift
@@ -239,7 +239,7 @@ public struct MpcCoreKit  {
             // if factor not found, continue forward and try to retrive device factor
             if factor != nil {
                 do {
-                    try await self.inputFactor(factorKey: factor)
+                    try await self.inputFactor(factorKey: factor!)
                     self.factorKey = factor
                     return
                 } catch {

--- a/Sources/mpc-core-kit-swift/tss.swift
+++ b/Sources/mpc-core-kit-swift/tss.swift
@@ -221,9 +221,7 @@ extension MpcCoreKit {
         guard let metadataPubKey = self.appState.metadataPubKey else {
             throw "invalid metadataPubKey"
         }
-        let full = try curveSecp256k1.PublicKey(hex: metadataPubKey).serialize(compressed: false)
-        let xCordinate = String(full.suffix(128).prefix(64))
-        
+       
         let hashFactorKey = try self.getHashKey()
         
         let additionalDeviceMetadata = await [

--- a/Sources/mpc-core-kit-swift/tss.swift
+++ b/Sources/mpc-core-kit-swift/tss.swift
@@ -128,7 +128,7 @@ extension MpcCoreKit {
     /// shareDescription?: FactorKeyTypeShareDescription;
     ///  * Additional metadata information you want to be stored alongside this factor for easy identification.
     /// additionalMetadata?: Record<string, string>;
-    public func createFactor( tssShareIndex: TssShareType, factorKey: String?, factorDescription: FactorDescriptionTypeModule, additionalMetadata: [String: Codable] = [:]) async throws -> String {
+    public func createFactor( tssShareIndex: TssShareType, factorKey: String?, factorDescription: FactorDescriptionTypeModule, additionalMetadata: [String: Any] = [:]) async throws -> String {
         // check for index is same as factor key
         guard let threshold_key = self.tkey else {
             throw "Invalid tkey"

--- a/Sources/mpc-core-kit-swift/tss.swift
+++ b/Sources/mpc-core-kit-swift/tss.swift
@@ -233,7 +233,7 @@ extension MpcCoreKit {
         let deviceFactor = try await self.createFactor(tssShareIndex: .DEVICE, factorKey: nil, factorDescription: .DeviceShare, additionalMetadata: additionalDeviceMetadata)
         
         // store to device
-        try await self.coreKitStorage.set(key: xCordinate , payload: deviceFactor)
+        try await self.setDeviceFactor(factorKey: deviceFactor)
         try await self.inputFactor(factorKey: deviceFactor)
         
         


### PR DESCRIPTION
## Description

Fixes couple of issues regarding EnableMFA

Issue: #11
The issue was because of a couple of reasons. First, we did not check the device factor, if hashed key was not found. Upon enable MFA hashed key is deleted, so we should check the device factor. Second, there was a type issue while retrieving the data from `ILocalStorage`. We were using `Codable` but default types of Swift are not Codable. Used `Any` instead of `Codable`.

Issue: #12
We were not adding the `deviceMetadataShareIndex` for new users, which is used to backup share in `enableMFA`. 

Issue: #8
Rename the `login` function to keep it align with mpc-core-kit-web