### PR TITLE
fix: use unfiltered share descriptions so that tss share description is not filtered out

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tkey/tkey-mpc-swift",
       "state" : {
-        "revision" : "74ea5301e316163b48e653ba107fd9edd4fe6bf8",
-        "version" : "4.0.2"
+        "branch" : "unfiltered_share_descriptions",
+        "revision" : "8ba15942dfecef421e5821ed3fdea1da0056be05"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/torusresearch/tss-client-swift.git", from: "5.0.1"),
-        .package(url: "https://github.com/tkey/tkey-mpc-swift", from: "4.0.2"),
+        // TODO: Update to 4.0.3 before merge, requires tagging on dependant PR
+        .package(url: "https://github.com/tkey/tkey-mpc-swift", branch: "unfiltered_share_descriptions"),
         .package(url: "https://github.com/torusresearch/customauth-swift-sdk", from: "11.0.2"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0")
     ],

--- a/Sources/mpc-core-kit-swift/MpcCoreKitSwift.swift
+++ b/Sources/mpc-core-kit-swift/MpcCoreKitSwift.swift
@@ -344,7 +344,7 @@ public class MpcCoreKit {
         let description = createCoreKitFactorDescription(module: descriptionTypeModule, tssIndex: tssIndex, dateAdded: Int(Date().timeIntervalSince1970))
         let jsonStr = try factorDescriptionToJsonStr(dataObj: description)
         try await tkey.add_share_description(key: factorPub, description: jsonStr)
-
+        
         self.factorKey = factorKey
         deviceMetadataShareIndex = shareIndexes[0]
 

--- a/mpc-core-kit-swift.podspec
+++ b/mpc-core-kit-swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "mpc-core-kit-swift"
-  spec.version      = "1.0.0"
+  spec.version      = "1.0.1"
   spec.platform = :ios, "14.0"
   spec.summary      = "Core Kit SDK"
   spec.homepage     = "https://web3auth.io/"


### PR DESCRIPTION
This PR removes the filter applied to the underlying share descriptions, thereby returning all results.